### PR TITLE
The curly braces in '${XDG_CACHE_HOME:-$HOME/.cache}/asp' seem to confuse the parser

### DIFF
--- a/man/asp.1.txt
+++ b/man/asp.1.txt
@@ -108,7 +108,7 @@ Environment
 -----------
 *ASPROOT*::
 	Determines where the metadata is stored for locally tracked packages. Defaults
-	to '${XDG_CACHE_HOME:-$HOME/.cache}/asp'.
+	to '`${XDG_CACHE_HOME:-$HOME/.cache}/asp`'.
 
 *ASPCACHE*::
 	Determines where cached data is stored. Defaults to '$ASPROOT/cache'. Data in


### PR DESCRIPTION
when generating a man page, the curly braces in '${XDG_CACHE_HOME:-$HOME/.cache}/asp' seem to confuse the parser and the entire line doesn't show up in the generated man page. This change uses an inline literal passthrough to avoid that.