### PR TITLE
fix possibility of corrupt caches

### DIFF
--- a/remote.inc.sh
+++ b/remote.inc.sh
@@ -5,8 +5,14 @@ __remote_refcache_update() {
   trap "rm -f '$cachefile~'" RETURN
 
   git ls-remote "$remote" 'refs/heads/packages/*' |
-      awk '{ sub(/refs\/heads\//, "", $2); print $2 }' >"$cachefile~" &&
-          mv "$cachefile"{~,}
+      awk '{ sub(/refs\/heads\//, "", $2); print $2 }' >"$cachefile~"
+
+  if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
+    rm -f "$cachefile~"
+    log_fatal 'Was not able to update remote-%s' "$remote"
+  fi
+
+  mv "$cachefile"{~,}
 }
 
 __remote_refcache_get() {


### PR DESCRIPTION
Bug: It is possible to get corrupt caches.
Steps to reproduce:

rm -rf ~/.cache/asp
Disconnect from the internet.
Try to export a package, for example: asp export asp
---Exporting fails, which is fine, since we are not connected to the internet---
Now connect to the internet again.
Try to export a package, again: asp export asp
--- Exporting still fails, which should not happen---

Simple if, which prevents generating corrupt caches fixes the problem.

