### PR TITLE
archweb_get_pkgbase: urlencode pkgname to allow packages containing `…

### DIFF
--- a/archweb.inc.sh
+++ b/archweb.inc.sh
@@ -1,4 +1,4 @@
 archweb_get_pkgbase() {
-  curl -s "https://www.archlinux.org/packages/search/json/?q=$1" |
+  curl -Gs "https://www.archlinux.org/packages/search/json/" --data-urlencode "q=$1" |
     jq -er --arg pkgname "$1" 'limit(1; .results[] | select(.pkgname == $pkgname).pkgbase)'
 }


### PR DESCRIPTION
…+` characters in the pkgname to be translated correctly

archweb_get_pkgbase currently does not urlencode the pkgname, which leads to issues for split packages like libsigc++-docs which have the character '+' in the pkgname.

for example, the following fails unexpectedly:
> $ asp list-repos libsigc++-docs
> error: unknown package: libsigc++-docs

the attached patch against falconindy/asp.git master uses the --data-urlencode option of curl to correct this problem. The added -G switch to curl forces a GET request, because --data-urlencode implies a POST request by default.

Steps to reproduce:

$ asp list-repos libsigc++-docs
error: unknown package: libsigc++-docs

or directly:

$ curl https://www.archlinux.org/packages/search/json/?q=libsigc++-docs
{"num_pages": 1, "results": [], "page": 1, "version": 2, "limit": 250, "valid": true}

I reported this on the arch bug tracker, but was met with limited enthusiasm:
https://bugs.archlinux.org/task/58091