### PR TITLE
parsing issue and missing function

### DIFF
--- a/asp.in
+++ b/asp.in
@@ -156,7 +156,7 @@ dump_packages() {
       dumpfn=remote_get_tracked_refs
       ;;
     *)
-      die 'internal error: invalid dump type: "%s"' "$1"
+      log_fatal 'BUG: invalid dump type: "%s"' "$1"
       ;;
   esac
 

--- a/package.inc.sh
+++ b/package.inc.sh
@@ -74,7 +74,7 @@ package_log() {
       logargs=()
       ;;
     *)
-      die 'internal error: unknown log method: %s' "$method"
+      log_fatal 'BUG: unknown log method: %s' "$method"
       ;;
   esac
 

--- a/package.inc.sh
+++ b/package.inc.sh
@@ -177,7 +177,9 @@ package_get_repos_with_arch() {
   pkgname=$1
 
   while read -r path; do
-    IFS=/- read -r _ repo arch <<<"$path"
+    path=${path##*/}
+    repo=${path%-*}
+    arch=${path##*-}
     printf '%s %s\n' "$repo" "$arch"
   done < <(git ls-tree --name-only "remotes/$remote/packages/$pkgname" repos/)
 }


### PR DESCRIPTION
I've been reading the source, and found two issues:
I found that in some parts a die() function is being called, however there's no such function available.
There's a string in the form of <repo>-<arch> which gets parsed to obtain a repo and arch variable, however in some scenarios it doesnt work properly.
I wrote patches to fix both issues.