### PR TITLE
Makefile: remove 'dist' dependency from .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,4 +54,4 @@ install: all
 	install -Dm644 $(BASH_COMPLETION) $(DESTDIR)$(PREFIX)/share/bash-completion/completions/asp
 	install -Dm644 $(ZSH_COMPLETION) $(DESTDIR)$(PREFIX)/share/zsh/site-functions/_asp
 
-.PHONY: all clean install uninstall dist
+.PHONY: all clean install uninstall


### PR DESCRIPTION
hi,
I just saw your latest commits after the merge and in the one when you remove 'dist' target from Makefile, you forgot to remove the dist dependency from .PHONY.