### PR TITLE
change to git-show for condition check

### DIFF
--- a/package.inc.sh
+++ b/package.inc.sh
@@ -135,7 +135,7 @@ package_export() {
     subtree=repos/$repo-$OPT_ARCH
   fi
 
-  if ! git ls-tree "remotes/$remote/packages/$pkgname" "$subtree/" &>/dev/null; then
+  if ! git show "remotes/$remote/packages/$pkgname:$subtree/" &>/dev/null; then
     if [[ $repo ]]; then
       log_error "package '%s' not found in repo '%s-%s'" "$pkgname" "$repo" "$OPT_ARCH"
       return 1


### PR DESCRIPTION
fixup: 0a6a4d0 Use exit status rather than string emptiness
- git-ls always returns 0 as exit status, so it can't be used
  as a check. However, git-show does return an error status.